### PR TITLE
ebless particles

### DIFF
--- a/src/core/data/particles/particle.hpp
+++ b/src/core/data/particles/particle.hpp
@@ -61,26 +61,17 @@ struct Particle
     std::array<double, dim> delta = ConstArray<double, dim>();
     std::array<double, 3> v       = ConstArray<double, 3>();
 
-    double Ex = 0, Ey = 0, Ez = 0;
-    double Bx = 0, By = 0, Bz = 0;
-
     NO_DISCARD bool operator==(Particle<dim> const& that) const
     {
         return (this->weight == that.weight) && //
                (this->charge == that.charge) && //
                (this->iCell == that.iCell) &&   //
                (this->delta == that.delta) &&   //
-               (this->v == that.v) &&           //
-               (this->Ex == that.Ex) &&         //
-               (this->Ey == that.Ey) &&         //
-               (this->Ez == that.Ez) &&         //
-               (this->Bx == that.Bx) &&         //
-               (this->By == that.By) &&         //
-               (this->Bz == that.Bz);
+               (this->v == that.v);
     }
 
     template<std::size_t dimension>
-    friend std::ostream& operator<<(std::ostream& out, const Particle<dimension>& particle);
+    friend std::ostream& operator<<(std::ostream& out, Particle<dimension> const& particle);
 };
 
 template<std::size_t dim>
@@ -102,8 +93,6 @@ std::ostream& operator<<(std::ostream& out, Particle<dim> const& particle)
         out << v << ",";
     }
     out << "), charge : " << particle.charge << ", weight : " << particle.weight;
-    out << ", Exyz : " << particle.Ex << "," << particle.Ey << "," << particle.Ez;
-    out << ", Bxyz : " << particle.Bx << "," << particle.By << "," << particle.Bz;
     out << '\n';
     return out;
 }
@@ -132,9 +121,9 @@ inline constexpr auto is_phare_particle_type
 
 template<std::size_t dim, template<std::size_t> typename ParticleA,
          template<std::size_t> typename ParticleB>
-NO_DISCARD typename std::enable_if_t<is_phare_particle_type<dim, ParticleA<dim>>
-                                         and is_phare_particle_type<dim, ParticleB<dim>>,
-                                     bool>
+NO_DISCARD typename std::enable_if_t<
+    is_phare_particle_type<dim, ParticleA<dim>> and is_phare_particle_type<dim, ParticleB<dim>>,
+    bool>
 operator==(ParticleA<dim> const& particleA, ParticleB<dim> const& particleB)
 {
     return particleA.weight == particleB.weight and //

--- a/src/core/data/particles/particle_array.hpp
+++ b/src/core/data/particles/particle_array.hpp
@@ -95,7 +95,7 @@ public:
     NO_DISCARD auto back() { return particles_.back(); }
     NO_DISCARD auto front() { return particles_.front(); }
 
-    auto erase(IndexRange_& range) { cellMap_.erase(particles_, range); }
+    auto erase(IndexRange_& range) { cellMap_.erase(range); }
     auto erase(IndexRange_&& range)
     {
         // TODO move ctor for range?
@@ -196,6 +196,12 @@ public:
     auto partition(Predicate&& pred)
     {
         return cellMap_.partition(makeIndexRange(*this), std::forward<Predicate>(pred));
+    }
+
+    template<typename Predicate, typename Range>
+    auto partition(Predicate&& pred, Range& range)
+    {
+        return cellMap_.partition(range, std::forward<Predicate>(pred));
     }
 
     template<typename CellIndex>

--- a/src/core/def.hpp
+++ b/src/core/def.hpp
@@ -1,6 +1,17 @@
 #ifndef PHARE_CORE_DEF_HPP
 #define PHARE_CORE_DEF_HPP
 
+
 #define NO_DISCARD [[nodiscard]]
+
+#if !defined(NDEBUG) || defined(PHARE_FORCE_DEBUG_DO)
+#define PHARE_DEBUG_DO(...) __VA_ARGS__
+#else
+#define PHARE_DEBUG_DO(...)
+#endif
+
+#define _PHARE_TO_STR(x) #x // convert macro text to string
+#define PHARE_TO_STR(x) _PHARE_TO_STR(x)
+
 
 #endif // PHARE_CORE_DEF_HPP

--- a/src/core/numerics/ion_updater/ion_updater.hpp
+++ b/src/core/numerics/ion_updater/ion_updater.hpp
@@ -18,10 +18,10 @@
 #include <cstddef>
 #include <memory>
 
-
 namespace PHARE::core
 {
 enum class UpdaterMode { domain_only = 1, all = 2 };
+
 
 template<typename Ions, typename Electromag, typename GridLayout>
 class IonUpdater
@@ -33,27 +33,28 @@ public:
     using Box               = PHARE::core::Box<int, dimension>;
     using Interpolator      = PHARE::core::Interpolator<dimension, interp_order>;
     using VecField          = typename Ions::vecfield_type;
-    using ParticleArray     = typename Ions::particle_array_type;
-    using Particle_t        = typename ParticleArray::Particle_t;
-    using PartIterator      = typename ParticleArray::iterator;
-    using ParticleRange     = IndexRange<ParticleArray>;
+    using ParticleArray_t   = typename Ions::particle_array_type;
+    using Particle_t        = typename ParticleArray_t::Particle_t;
+    using PartIterator      = typename ParticleArray_t::iterator;
+    using ParticleRange     = IndexRange<ParticleArray_t>;
     using BoundaryCondition = PHARE::core::BoundaryCondition<dimension, interp_order>;
-    using Pusher = PHARE::core::Pusher<dimension, ParticleRange, Electromag, Interpolator,
-                                       BoundaryCondition, GridLayout>;
+    using Pusher = PHARE::core::BorisPusher<dimension, ParticleRange, Electromag, Interpolator,
+                                            BoundaryCondition, GridLayout>;
 
 private:
     constexpr static auto makePusher
         = PHARE::core::PusherFactory::makePusher<dimension, ParticleRange, Electromag, Interpolator,
                                                  BoundaryCondition, GridLayout>;
 
-    std::unique_ptr<Pusher> pusher_;
+    std::unique_ptr<Pusher> pusher_ = std::make_unique<Pusher>();
     Interpolator interpolator_;
 
 public:
     IonUpdater(PHARE::initializer::PHAREDict const& dict)
-        : pusher_{makePusher(dict["pusher"]["name"].template to<std::string>())}
+    //: pusher_{makePusher(dict["pusher"]["name"].template to<std::string>())}
     {
     }
+
 
     void updatePopulations(Ions& ions, Electromag const& em, GridLayout const& layout, double dt,
                            UpdaterMode = UpdaterMode::all);
@@ -66,6 +67,17 @@ private:
     void updateAndDepositDomain_(Ions& ions, Electromag const& em, GridLayout const& layout);
 
     void updateAndDepositAll_(Ions& ions, Electromag const& em, GridLayout const& layout);
+
+
+
+    auto interop_end(std::size_t const& it, ParticleArray_t const& particles) const
+    {
+        return particles.size() < EB_interop::size() ? particles.size() : EB_interop::size() * it;
+    }
+    auto interop_begin(std::int64_t const& end, ParticleArray_t const& particles) const
+    {
+        return end - EB_interop::size() >= 0 ? end - EB_interop::size() : 0;
+    }
 };
 
 
@@ -112,71 +124,76 @@ void IonUpdater<Ions, Electromag, GridLayout>::updateAndDepositDomain_(Ions& ion
                                                                        GridLayout const& layout)
 {
     PHARE_LOG_SCOPE("IonUpdater::updateAndDepositDomain_");
-
-    auto domainBox = layout.AMRBox();
-
-    auto inDomainBox = [&domainBox](auto& particleRange) //
-    {
-        auto& box = domainBox;
+    auto constexpr partGhostWidth = GridLayout::nbrParticleGhosts();
+    auto domainBox                = layout.AMRBox();
+    auto inDomainBox              = [&](auto& particleRange) {
         return particleRange.array().partition(
-            [&](auto const& cell) { return core::isIn(Point{cell}, box); });
+            [&](auto const& cell) { return core::isIn(Point{cell}, domainBox); }, particleRange);
     };
 
-    auto constexpr partGhostWidth = GridLayout::nbrParticleGhosts();
-    auto ghostBox{domainBox};
-    ghostBox.grow(partGhostWidth);
-
+    auto ghostBox   = grow(domainBox, partGhostWidth);
     auto inGhostBox = [&](auto& particleRange) {
         return particleRange.array().partition(
-            [&](auto const& cell) { return isIn(Point{cell}, ghostBox); });
+            [&](auto const& cell) { return isIn(Point{cell}, ghostBox); }, particleRange);
     };
 
     for (auto& pop : ions)
     {
-        ParticleArray& domain = pop.domainParticles();
+        ParticleArray_t& domain = pop.domainParticles();
 
         // first push all domain particles
         // push them while still inDomainBox
         // accumulate those inDomainBox
         // erase those which left
 
-        auto inRange  = makeIndexRange(domain);
-        auto outRange = makeIndexRange(domain);
+        std::size_t deleted    = 0;
+        std::size_t iterations = ceil(domain.size(), EB_interop::size());
+        for (std::size_t it = iterations; it > 0; --it)
+        {
+            std::size_t end   = interop_end(it, domain) - deleted;
+            std::size_t begin = interop_begin(end, domain);
+            auto inRange      = makeIndexRange(domain, begin, end);
+            auto outRange     = makeIndexRange(domain, begin, end);
+            outRange          = pusher_->move_first(inRange, outRange);
+            auto inDomain     = inDomainBox(
+                    pusher_->move_second(outRange, em, pop.mass(), interpolator_, layout));
+            interpolator_(inDomain, pop.density(), pop.flux(), layout);
 
-        auto inDomain = pusher_->move(
-            inRange, outRange, em, pop.mass(), interpolator_, layout,
-            [](auto& particleRange) { return particleRange; }, inDomainBox);
+            // TODO : we can erase here because we know we are working on a state
+            // that has been saved in the solverPPC
+            // this makes the updater quite coupled to how the solverPPC works while
+            // it kind of pretends not to be by being independent object in core...
+            // note we need to erase here if using the back_inserter for ghost copy
+            // otherwise they will be added after leaving domain particles.
 
-        interpolator_(inDomain, pop.density(), pop.flux(), layout);
+            auto toErase = makeRange(domain, inDomain.iend(), end);
+            domain.erase(toErase);
+            deleted += toErase.size();
+        }
 
-        // TODO : we can erase here because we know we are working on a state
-        // that has been saved in the solverPPC
-        // this makes the updater quite coupled to how the solverPPC works while
-        // it kind of pretends not to be by being independent object in core...
-        // note we need to erase here if using the back_inserter for ghost copy
-        // otherwise they will be added after leaving domain particles.
-        domain.erase(makeRange(domain, inDomain.iend(), domain.size()));
 
         // then push patch and level ghost particles
         // push those in the ghostArea (i.e. stop pushing if they're not out of it)
         // deposit moments on those which leave to go inDomainBox
 
         auto pushAndAccumulateGhosts = [&](auto& inputArray, bool copyInDomain = false) {
-            auto outputArray{inputArray}; // TODO : dynamic allocation can we get rid of that
-            //      eventually?
-
-            inRange  = makeIndexRange(inputArray);
-            outRange = makeIndexRange(outputArray);
-
-            auto enteredInDomain = pusher_->move(inRange, outRange, em, pop.mass(), interpolator_,
-                                                 layout, inGhostBox, inDomainBox);
-
-            interpolator_(enteredInDomain, pop.density(), pop.flux(), layout);
-
-            if (copyInDomain)
+            auto outputArray       = inputArray;
+            std::size_t iterations = ceil(outputArray.size(), EB_interop::size());
+            for (std::size_t it = iterations; it > 0; --it)
             {
-                std::copy(enteredInDomain.begin(), enteredInDomain.end(),
-                          std::back_inserter(domain));
+                std::size_t end      = interop_end(it, outputArray);
+                std::size_t begin    = interop_begin(end, outputArray);
+                auto inRange         = makeIndexRange(outputArray, begin, end);
+                auto outRange        = makeIndexRange(outputArray, begin, end);
+                outRange             = inGhostBox(pusher_->move_first(inRange, outRange));
+                auto enteredInDomain = inDomainBox(
+                    pusher_->move_second(outRange, em, pop.mass(), interpolator_, layout));
+                interpolator_(enteredInDomain, pop.density(), pop.flux(), layout);
+                if (copyInDomain)
+                {
+                    std::copy(enteredInDomain.begin(), enteredInDomain.end(),
+                              std::back_inserter(domain));
+                }
             }
         };
 
@@ -204,28 +221,25 @@ void IonUpdater<Ions, Electromag, GridLayout>::updateAndDepositAll_(Ions& ions,
                                                                     GridLayout const& layout)
 {
     PHARE_LOG_SCOPE("IonUpdater::updateAndDepositAll_");
-
     auto constexpr partGhostWidth = GridLayout::nbrParticleGhosts();
     auto domainBox                = layout.AMRBox();
-    auto ghostBox{domainBox};
-    ghostBox.grow(partGhostWidth);
-
-    auto inDomainBox = [&domainBox](auto& particleRange) //
-    {
+    auto inDomainBox              = [&domainBox](auto& particleRange) {
         return particleRange.array().partition(
-            [&](auto const& cell) { return isIn(Point{cell}, domainBox); });
+            [&](auto const& cell) { return isIn(Point{cell}, domainBox); }, particleRange);
     };
 
+    auto ghostBox   = grow(domainBox, partGhostWidth);
     auto inGhostBox = [&](auto& particleRange) {
         return particleRange.array().partition(
-            [&](auto const& cell) { return isIn(Point{cell}, ghostBox); });
+            [&](auto const& cell) { return isIn(Point{cell}, ghostBox); }, particleRange);
     };
 
-
     auto inGhostLayer = [&](auto& particleRange) {
-        return particleRange.array().partition([&](auto const& cell) {
-            return isIn(Point{cell}, ghostBox) and !isIn(Point{cell}, domainBox);
-        });
+        return particleRange.array().partition(
+            [&](auto const& cell) {
+                return isIn(Point{cell}, ghostBox) and !isIn(Point{cell}, domainBox);
+            },
+            particleRange);
     };
 
     // push domain particles, erase from array those leaving domain
@@ -234,29 +248,45 @@ void IonUpdater<Ions, Electromag, GridLayout>::updateAndDepositAll_(Ions& ions,
     // finally all particles in domain are to be interpolated on mesh.
     for (auto& pop : ions)
     {
-        auto& domainParticles = pop.domainParticles();
-        auto domainPartRange  = makeIndexRange(domainParticles);
+        auto& domainParticles  = pop.domainParticles();
+        std::size_t deleted    = 0;
+        std::size_t iterations = ceil(domainParticles.size(), EB_interop::size());
+        for (std::size_t it = iterations; it > 0; --it)
+        {
+            std::size_t end      = interop_end(it, domainParticles) - deleted;
+            std::size_t begin    = interop_begin(end, domainParticles);
+            auto domainPartRange = makeIndexRange(domainParticles, begin, end);
+            domainPartRange      = pusher_->move_first(domainPartRange, domainPartRange);
+            auto inDomain        = inDomainBox(
+                       pusher_->move_second(domainPartRange, em, pop.mass(), interpolator_, layout));
+            auto toErase = makeRange(domainParticles, inDomain.iend(), end);
+            domainParticles.erase(toErase);
+            deleted += toErase.size();
+        }
 
-        auto inDomain = pusher_->move(
-            domainPartRange, domainPartRange, em, pop.mass(), interpolator_, layout,
-            [](auto const& particleRange) { return particleRange; }, inDomainBox);
 
-        domainParticles.erase(makeRange(domainParticles, inDomain.iend(), domainParticles.size()));
-
-        auto pushAndCopyInDomain = [&](auto&& particleRange) {
-            auto inGhostLayerRange = pusher_->move(particleRange, particleRange, em, pop.mass(),
-                                                   interpolator_, layout, inGhostBox, inGhostLayer);
-
-            auto& particleArray = particleRange.array();
-            particleArray.export_particles(
-                domainParticles, [&](auto const& cell) { return isIn(Point{cell}, domainBox); });
-
-            particleArray.erase(
-                makeRange(particleArray, inGhostLayerRange.iend(), particleArray.size()));
+        auto pushAndCopyInDomain = [&](auto& particleArray) {
+            std::size_t deleted    = 0;
+            std::size_t iterations = ceil(particleArray.size(), EB_interop::size());
+            for (std::size_t it = iterations; it > 0; --it)
+            {
+                std::size_t end    = interop_end(it, particleArray) - deleted;
+                std::size_t begin  = interop_begin(end, particleArray);
+                auto particleRange = makeIndexRange(particleArray, begin, end);
+                particleRange      = inGhostBox(pusher_->move_first(particleRange, particleRange));
+                auto inGhostLayerRange
+                    = pusher_->move_second(particleRange, em, pop.mass(), interpolator_, layout);
+                particleArray.export_particles(domainParticles, [&](auto const& cell) {
+                    return isIn(Point{cell}, domainBox);
+                });
+                auto toErase = makeRange(particleArray, inGhostLayerRange.iend(), end);
+                particleArray.erase(toErase);
+                deleted += toErase.size();
+            }
         };
 
-        pushAndCopyInDomain(makeIndexRange(pop.patchGhostParticles()));
-        pushAndCopyInDomain(makeIndexRange(pop.levelGhostParticles()));
+        pushAndCopyInDomain(pop.patchGhostParticles());
+        pushAndCopyInDomain(pop.levelGhostParticles());
 
         interpolator_(makeIndexRange(domainParticles), pop.density(), pop.flux(), layout);
     }

--- a/src/core/utilities/box/box.hpp
+++ b/src/core/utilities/box/box.hpp
@@ -257,8 +257,8 @@ NO_DISCARD bool isIn(Point const& point,
 }
 
 
-template<typename Type, std::size_t dim>
-Box<Type, dim> grow(Box<Type, dim> const& box, Type const& size)
+template<typename Type, std::size_t dim, typename OType>
+Box<Type, dim> grow(Box<Type, dim> const& box, OType const& size)
 {
     auto copy{box};
     copy.grow(size);

--- a/src/core/utilities/cellmap.hpp
+++ b/src/core/utilities/cellmap.hpp
@@ -170,6 +170,8 @@ public:
     // erase all items indexed in the given range from both the cellmap and the
     // array the range is for.
     template<typename Range>
+    void erase(Range& range);
+    template<typename Range>
     void erase(Range&& range);
 
 
@@ -418,9 +420,9 @@ inline auto CellMap<dim, cell_index_t>::partition(Range range, Predicate&& pred,
     auto pivot              = range.iend();
     for (auto const& cell : box_)
     {
-        auto& itemIndexes = cellIndexes_(local_(cell));
         if (!pred(cell))
         {
+            auto& itemIndexes = cellIndexes_(local_(cell));
             for (auto currentIdx : itemIndexes)
             {
                 // partition only indexes in range
@@ -451,7 +453,7 @@ inline auto CellMap<dim, cell_index_t>::partition(Range range, Predicate&& pred,
         }
     }
 
-    return makeRange(range.array(), range.ibegin(), range.ibegin() + pivot);
+    return makeRange(range.array(), range.ibegin(), pivot);
 }
 
 
@@ -459,7 +461,7 @@ inline auto CellMap<dim, cell_index_t>::partition(Range range, Predicate&& pred,
 
 template<std::size_t dim, typename cell_index_t>
 template<typename Range>
-inline void CellMap<dim, cell_index_t>::erase(Range&& range)
+inline void CellMap<dim, cell_index_t>::erase(Range& range)
 {
     auto& items = range.array();
 
@@ -470,6 +472,13 @@ inline void CellMap<dim, cell_index_t>::erase(Range&& range)
         erase(items, i);
     }
     items.erase(range.begin(), range.end());
+}
+
+template<std::size_t dim, typename cell_index_t>
+template<typename Range>
+inline void CellMap<dim, cell_index_t>::erase(Range&& range)
+{
+    erase(range);
 }
 
 

--- a/src/core/utilities/range/range.hpp
+++ b/src/core/utilities/range/range.hpp
@@ -72,7 +72,7 @@ namespace core
         NO_DISCARD auto begin() const { return std::begin(*array_) + first_; }
         NO_DISCARD auto end() const { return std::begin(*array_) + end_; }
         NO_DISCARD auto& array() { return *array_; }
-        NO_DISCARD auto const& array() const { return *array_; }
+        NO_DISCARD auto& array() const { return *array_; }
 
         // these ones are not used for now... they give access to the array element
         // via a range index (i.e. not an array index, but relative to the array index
@@ -116,6 +116,11 @@ namespace core
     NO_DISCARD auto makeIndexRange(Container& container)
     {
         return IndexRange<Container>{container, 0, container.size()};
+    }
+    template<typename Container, typename Index>
+    NO_DISCARD auto makeIndexRange(Container& container, Index first, Index end)
+    {
+        return IndexRange<Container>{container, first, end};
     }
 
     template<typename Container>

--- a/src/core/utilities/types.hpp
+++ b/src/core/utilities/types.hpp
@@ -19,15 +19,6 @@
 
 #include "cppdict/include/dict.hpp"
 
-#if !defined(NDEBUG) || defined(PHARE_FORCE_DEBUG_DO)
-#define PHARE_DEBUG_DO(...) __VA_ARGS__
-#else
-#define PHARE_DEBUG_DO(...)
-#endif
-
-#define _PHARE_TO_STR(x) #x // convert macro text to string
-#define PHARE_TO_STR(x) _PHARE_TO_STR(x)
-
 namespace PHARE
 {
 namespace core
@@ -345,6 +336,16 @@ NO_DISCARD auto none(Container const& container)
 }
 
 
+template<typename F = float, typename T, typename D>
+auto ceil(T const& t, D const& d)
+{
+    return static_cast<T>(std::ceil(static_cast<F>(t) / d));
+}
+template<typename F = float, typename T, typename D>
+auto floor(T const& t, D const& d)
+{
+    return static_cast<T>(std::floor(static_cast<F>(t) / d));
+}
 
 
 } // namespace PHARE::core

--- a/tests/amr/data/particles/copy/test_particledata_copyNd.cpp
+++ b/tests/amr/data/particles/copy/test_particledata_copyNd.cpp
@@ -117,12 +117,6 @@ TYPED_TEST(AParticlesDataND, PreservesAllParticleAttributesAfterCopy)
                 Pointwise(DoubleEq(), this->particle.delta));
     EXPECT_THAT(this->destData.domainParticles[0].weight, DoubleEq(this->particle.weight));
     EXPECT_THAT(this->destData.domainParticles[0].charge, DoubleEq(this->particle.charge));
-    EXPECT_DOUBLE_EQ(this->destData.domainParticles[0].Ex, this->particle.Ex);
-    EXPECT_DOUBLE_EQ(this->destData.domainParticles[0].Ey, this->particle.Ey);
-    EXPECT_DOUBLE_EQ(this->destData.domainParticles[0].Ez, this->particle.Ez);
-    EXPECT_DOUBLE_EQ(this->destData.domainParticles[0].Bx, this->particle.Bx);
-    EXPECT_DOUBLE_EQ(this->destData.domainParticles[0].By, this->particle.By);
-    EXPECT_DOUBLE_EQ(this->destData.domainParticles[0].Bz, this->particle.Bz);
 
     // particle is in the domain of the source patchdata
     // and in last ghost of the destination patchdata
@@ -138,12 +132,6 @@ TYPED_TEST(AParticlesDataND, PreservesAllParticleAttributesAfterCopy)
                 Pointwise(DoubleEq(), this->particle.delta));
     EXPECT_THAT(this->destData.patchGhostParticles[0].weight, DoubleEq(this->particle.weight));
     EXPECT_THAT(this->destData.patchGhostParticles[0].charge, DoubleEq(this->particle.charge));
-    EXPECT_DOUBLE_EQ(this->destData.patchGhostParticles[0].Ex, this->particle.Ex);
-    EXPECT_DOUBLE_EQ(this->destData.patchGhostParticles[0].Ey, this->particle.Ey);
-    EXPECT_DOUBLE_EQ(this->destData.patchGhostParticles[0].Ez, this->particle.Ez);
-    EXPECT_DOUBLE_EQ(this->destData.patchGhostParticles[0].Bx, this->particle.Bx);
-    EXPECT_DOUBLE_EQ(this->destData.patchGhostParticles[0].By, this->particle.By);
-    EXPECT_DOUBLE_EQ(this->destData.patchGhostParticles[0].Bz, this->particle.Bz);
 }
 
 

--- a/tests/amr/data/particles/copy_overlap/test_particledata_copy_periodicNd.cpp
+++ b/tests/amr/data/particles/copy_overlap/test_particledata_copy_periodicNd.cpp
@@ -135,12 +135,6 @@ TYPED_TEST(twoParticlesDataNDTouchingPeriodicBorders, preserveParticleAttributes
     EXPECT_THAT(this->destPdat.patchGhostParticles[0].delta, Eq(this->particle.delta));
     EXPECT_THAT(this->destPdat.patchGhostParticles[0].weight, Eq(this->particle.weight));
     EXPECT_THAT(this->destPdat.patchGhostParticles[0].charge, Eq(this->particle.charge));
-    EXPECT_DOUBLE_EQ(this->destPdat.patchGhostParticles[0].Ex, this->particle.Ex);
-    EXPECT_DOUBLE_EQ(this->destPdat.patchGhostParticles[0].Ey, this->particle.Ey);
-    EXPECT_DOUBLE_EQ(this->destPdat.patchGhostParticles[0].Ez, this->particle.Ez);
-    EXPECT_DOUBLE_EQ(this->destPdat.patchGhostParticles[0].Bx, this->particle.Bx);
-    EXPECT_DOUBLE_EQ(this->destPdat.patchGhostParticles[0].By, this->particle.By);
-    EXPECT_DOUBLE_EQ(this->destPdat.patchGhostParticles[0].Bz, this->particle.Bz);
 }
 
 

--- a/tests/amr/data/particles/stream_pack/test_main.cpp
+++ b/tests/amr/data/particles/stream_pack/test_main.cpp
@@ -226,12 +226,6 @@ TYPED_TEST(StreamPackTest,
     EXPECT_THAT(destData.domainParticles[0].delta, Eq(particle.delta));
     EXPECT_THAT(destData.domainParticles[0].weight, Eq(particle.weight));
     EXPECT_THAT(destData.domainParticles[0].charge, Eq(particle.charge));
-    EXPECT_DOUBLE_EQ(destData.domainParticles[0].Ex, particle.Ex);
-    EXPECT_DOUBLE_EQ(destData.domainParticles[0].Ey, particle.Ey);
-    EXPECT_DOUBLE_EQ(destData.domainParticles[0].Ez, particle.Ez);
-    EXPECT_DOUBLE_EQ(destData.domainParticles[0].Bx, particle.Bx);
-    EXPECT_DOUBLE_EQ(destData.domainParticles[0].By, particle.By);
-    EXPECT_DOUBLE_EQ(destData.domainParticles[0].Bz, particle.Bz);
 }
 
 
@@ -269,12 +263,6 @@ TYPED_TEST(StreamPackTest,
     EXPECT_THAT(destData.patchGhostParticles[0].delta, Eq(particle.delta));
     EXPECT_THAT(destData.patchGhostParticles[0].weight, Eq(particle.weight));
     EXPECT_THAT(destData.patchGhostParticles[0].charge, Eq(particle.charge));
-    EXPECT_DOUBLE_EQ(destData.patchGhostParticles[0].Ex, particle.Ex);
-    EXPECT_DOUBLE_EQ(destData.patchGhostParticles[0].Ey, particle.Ey);
-    EXPECT_DOUBLE_EQ(destData.patchGhostParticles[0].Ez, particle.Ez);
-    EXPECT_DOUBLE_EQ(destData.patchGhostParticles[0].Bx, particle.Bx);
-    EXPECT_DOUBLE_EQ(destData.patchGhostParticles[0].By, particle.By);
-    EXPECT_DOUBLE_EQ(destData.patchGhostParticles[0].Bz, particle.Bz);
 }
 
 

--- a/tests/core/data/particles/test_main.cpp
+++ b/tests/core/data/particles/test_main.cpp
@@ -38,17 +38,6 @@ TEST_F(AParticle, ParticleChargeIsInitiliazedOK)
     EXPECT_DOUBLE_EQ(1., part.charge);
 }
 
-TEST_F(AParticle, ParticleFieldsAreInitializedToZero)
-{
-    EXPECT_DOUBLE_EQ(0.0, part.Ex);
-    EXPECT_DOUBLE_EQ(0.0, part.Ey);
-    EXPECT_DOUBLE_EQ(0.0, part.Ez);
-
-    EXPECT_DOUBLE_EQ(0.0, part.Bx);
-    EXPECT_DOUBLE_EQ(0.0, part.By);
-    EXPECT_DOUBLE_EQ(0.0, part.Bz);
-}
-
 
 TEST_F(AParticle, ParticleVelocityIsInitializedOk)
 {

--- a/tests/core/numerics/interpolator/test_main.cpp
+++ b/tests/core/numerics/interpolator/test_main.cpp
@@ -298,32 +298,20 @@ TYPED_TEST(A1DInterpolator, canComputeAllEMfieldsAtParticle)
     this->em.B.setBuffer("EM_B_y", &this->by1d_);
     this->em.B.setBuffer("EM_B_z", &this->bz1d_);
 
-    this->interp(makeIndexRange(this->particles), this->em, this->layout);
+    auto& eb_interop = this->interp(makeIndexRange(this->particles), this->em, this->layout);
 
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ex - this->ex0) < 1e-8; }));
+    for (auto const& [E, B] : eb_interop(this->particles))
+    {
+        auto const& [Ex, Ey, Ez] = E;
+        EXPECT_TRUE(std::abs(Ex - this->ex0) < 1e-8);
+        EXPECT_TRUE(std::abs(Ey - this->ey0) < 1e-8);
+        EXPECT_TRUE(std::abs(Ez - this->ez0) < 1e-8);
 
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ey - this->ey0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ez - this->ez0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Bx - this->bx0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.By - this->by0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Bz - this->bz0) < 1e-8; }));
-
+        auto const& [Bx, By, Bz] = B;
+        EXPECT_TRUE(std::abs(Bx - this->bx0) < 1e-8);
+        EXPECT_TRUE(std::abs(By - this->by0) < 1e-8);
+        EXPECT_TRUE(std::abs(Bz - this->bz0) < 1e-8);
+    }
 
     this->em.E.setBuffer("EM_E_x", nullptr);
     this->em.E.setBuffer("EM_E_y", nullptr);
@@ -421,31 +409,22 @@ TYPED_TEST(A2DInterpolator, canComputeAllEMfieldsAtParticle)
     this->em.B.setBuffer("EM_B_y", &this->by_);
     this->em.B.setBuffer("EM_B_z", &this->bz_);
 
-    this->interp(makeIndexRange(this->particles), this->em, this->layout);
+    auto& eb_interop = this->interp(makeIndexRange(this->particles), this->em, this->layout);
 
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ex - this->ex0) < 1e-8; }));
 
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ey - this->ey0) < 1e-8; }));
+    for (auto const& [E, B] : eb_interop(this->particles))
+    {
+        auto const& [Ex, Ey, Ez] = E;
+        EXPECT_TRUE(std::abs(Ex - this->ex0) < 1e-8);
+        EXPECT_TRUE(std::abs(Ey - this->ey0) < 1e-8);
+        EXPECT_TRUE(std::abs(Ez - this->ez0) < 1e-8);
 
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ez - this->ez0) < 1e-8; }));
+        auto const& [Bx, By, Bz] = B;
+        EXPECT_TRUE(std::abs(Bx - this->bx0) < 1e-8);
+        EXPECT_TRUE(std::abs(By - this->by0) < 1e-8);
+        EXPECT_TRUE(std::abs(Bz - this->bz0) < 1e-8);
+    }
 
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Bx - this->bx0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.By - this->by0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Bz - this->bz0) < 1e-8; }));
 
 
     this->em.E.setBuffer("EM_E_x", nullptr);
@@ -549,31 +528,21 @@ TYPED_TEST(A3DInterpolator, canComputeAllEMfieldsAtParticle)
     this->em.B.setBuffer("EM_B_y", &this->by_);
     this->em.B.setBuffer("EM_B_z", &this->bz_);
 
-    this->interp(makeIndexRange(this->particles), this->em, this->layout);
+    auto& eb_interop = this->interp(makeIndexRange(this->particles), this->em, this->layout);
 
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ex - this->ex0) < 1e-8; }));
 
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ey - this->ey0) < 1e-8; }));
+    for (auto const& [E, B] : eb_interop(this->particles))
+    {
+        auto const& [Ex, Ey, Ez] = E;
+        EXPECT_TRUE(std::abs(Ex - this->ex0) < 1e-8);
+        EXPECT_TRUE(std::abs(Ey - this->ey0) < 1e-8);
+        EXPECT_TRUE(std::abs(Ez - this->ez0) < 1e-8);
 
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Ez - this->ez0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Bx - this->bx0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.By - this->by0) < 1e-8; }));
-
-    EXPECT_TRUE(
-        std::all_of(std::begin(this->particles), std::end(this->particles),
-                    [this](auto const& part) { return std::abs(part.Bz - this->bz0) < 1e-8; }));
+        auto const& [Bx, By, Bz] = B;
+        EXPECT_TRUE(std::abs(Bx - this->bx0) < 1e-8);
+        EXPECT_TRUE(std::abs(By - this->by0) < 1e-8);
+        EXPECT_TRUE(std::abs(Bz - this->bz0) < 1e-8);
+    }
 
 
     this->em.E.setBuffer("EM_E_x", nullptr);

--- a/tests/core/numerics/pusher/test_pusher.cpp
+++ b/tests/core/numerics/pusher/test_pusher.cpp
@@ -20,6 +20,7 @@
 using namespace PHARE::core;
 
 
+
 struct Trajectory
 {
     std::vector<float> x, y, z;
@@ -70,19 +71,31 @@ Trajectory readExpectedTrajectory()
 // to test the pusher.
 class Interpolator
 {
+    using E_B_tuple  = std::tuple<std::array<double, 3>, std::array<double, 3>>;
+    using E_B_tupleV = std::vector<E_B_tuple>;
+    E_B_tupleV eb_interop;
+
 public:
     template<typename ParticleRange, typename Electromag, typename GridLayout>
-    void operator()(ParticleRange particles, Electromag const&, GridLayout&)
+    auto& operator()(ParticleRange particles, Electromag const&, GridLayout&)
     {
-        for (auto currPart = std::begin(particles); currPart != std::end(particles); ++currPart)
+        eb_interop.resize(particles.size());
+        std::size_t eb = 0;
+        for (auto currPart = std::begin(particles); currPart != std::end(particles);
+             ++currPart, ++eb)
         {
-            currPart->Ex = 0.01;
-            currPart->Ey = -0.05;
-            currPart->Ez = 0.05;
-            currPart->Bx = 1.;
-            currPart->By = 1.;
-            currPart->Bz = 1.;
+            auto& [pE, pB]        = eb_interop[eb];
+            auto& [pEx, pEy, pEz] = pE;
+            auto& [pBx, pBy, pBz] = pB;
+
+            pEx = 0.01;
+            pEy = -0.05;
+            pEz = 0.05;
+            pBx = 1.;
+            pBy = 1.;
+            pBz = 1.;
         }
+        return eb_interop;
     }
 };
 
@@ -132,6 +145,7 @@ public:
         , tstart{0}
         , tend{10}
         , nt{static_cast<std::size_t>((tend - tstart) / dt + 1)}
+
     {
         particlesIn.emplace_back(
             Particle{1., 1., ConstArray<int, dim>(5), ConstArray<double, dim>(0.), {0., 10., 0.}});
@@ -183,9 +197,7 @@ TEST_F(APusher3D, trajectoryIsOk)
         actual[2][i]
             = (particlesOut[0].iCell[2] + particlesOut[0].delta[2]) * static_cast<float>(dxyz[2]);
 
-        pusher->move(
-            rangeIn, rangeOut, em, mass, interpolator, layout,
-            [](decltype(rangeIn)& rge) { return rge; }, selector);
+        pusher->move(rangeIn, rangeOut, em, mass, interpolator, layout, selector, selector);
 
         std::copy(rangeOut.begin(), rangeOut.end(), rangeIn.begin());
     }
@@ -211,9 +223,7 @@ TEST_F(APusher2D, trajectoryIsOk)
         actual[1][i]
             = (particlesOut[0].iCell[1] + particlesOut[0].delta[1]) * static_cast<float>(dxyz[1]);
 
-        pusher->move(
-            rangeIn, rangeOut, em, mass, interpolator, layout, [](auto& rge) { return rge; },
-            selector);
+        pusher->move(rangeIn, rangeOut, em, mass, interpolator, layout, selector, selector);
 
         std::copy(rangeOut.begin(), rangeOut.end(), rangeIn.begin());
     }

--- a/tests/core/utilities/cellmap/test_cellmap.cpp
+++ b/tests/core/utilities/cellmap/test_cellmap.cpp
@@ -442,6 +442,34 @@ TEST_F(CellMappedParticleBox, partitionsParticlesInPatchBox)
     }
 }
 
+
+
+TEST_F(CellMappedParticleBox, partitionsParticlesRangeInPatchBox)
+{
+    EXPECT_EQ(cm.size(), particles.size());
+
+    auto isInPatchBox = [&](auto const& cell) { return isIn(Point{cell}, patchBox); };
+    auto allParts     = makeIndexRange(particles, particles.size() / 2, particles.size());
+    auto inPatchRange = cm.partition(allParts, isInPatchBox);
+
+    std::size_t count = 0;
+    for (auto const& p : particles)
+        count += isIn(Point{p.iCell}, patchBox) ? 1 : 0;
+
+    EXPECT_EQ(count, patchBox.size() * nppc);
+    for (std::size_t idx = inPatchRange.ibegin(); idx < inPatchRange.iend(); ++idx)
+    {
+        EXPECT_TRUE(isIn(Point{particles[idx].iCell}, patchBox));
+    }
+    for (std::size_t idx = inPatchRange.iend(); idx < particles.size(); ++idx)
+    {
+        EXPECT_FALSE(isIn(Point{particles[idx].iCell}, patchBox));
+    }
+}
+
+
+
+
 TEST_F(CellMappedParticleBox, allButOneParticleSatisfyPredicate)
 {
     EXPECT_EQ(cm.size(), particles.size());


### PR DESCRIPTION
[justification](https://gist.githubusercontent.com/PhilipDeegan/5145c7d37ab8822c3ce2c418b78e4a6a/raw/656f482fb549294101ddc74aa55193c581a349fa/eb)

https://coliru.stacked-crooked.com/a/00d8584545aea661

```
sizeof 1d particle: 56 bytes
how many millions fit in 10GB
178.571429 - NO EB ON PARTICLE
 96.153846 - EB ON PARTICLE

sizeof 2d particle: 64 bytes
how many millions fit in 10GB
156.250000 - NO EB ON PARTICLE
 89.285714 - EB ON PARTICLE

sizeof 3d particle: 80 bytes
how many millions fit in 10GB
125.000000 - NO EB ON PARTICLE
 78.125000 - EB ON PARTICLE
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added signal handling mechanism to track and handle signals during simulation.
  - Introduced new functions for particle movement and erasing in the `IonUpdater` class.
  - Added new `partition` and `erase` functions to the `ParticleArray` and `CellMappedParticleBox` classes.
- **Bug Fixes**
  - Modified the `grow` function in the `Box` template to accept a different type for the `size` parameter.
- **Refactor**
  - Removed certain fields from the `Particle` struct and updated related functions.
  - Refactored test cases for computing electromagnetic fields at particle positions.
- **Tests**
  - Updated test cases to reflect changes in the `Particle` struct and the `Interpolator` class.
  - Added a new test case for partitioning particles within a specified range in the patch box.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->