### PR TITLE
boundary conditions from python3 to hdf5

### DIFF
--- a/pyphare/pyphare/pharein/__init__.py
+++ b/pyphare/pyphare/pharein/__init__.py
@@ -137,7 +137,6 @@ def populateDict():
 
     add_string("simulation/name", "simulation_test")
     add_int("simulation/dimension", simulation.ndim)
-    add_string("simulation/boundary_types", simulation.boundary_types[0])
 
     if simulation.smallest_patch_size is not None:
         add_vector_int(
@@ -152,16 +151,19 @@ def populateDict():
     add_int("simulation/grid/nbr_cells/x", simulation.cells[0])
     add_double("simulation/grid/meshsize/x", simulation.dl[0])
     add_double("simulation/grid/origin/x", simulation.origin[0])
+    add_string("simulation/grid/boundary_type/x", simulation.boundary_types[0])
 
     if simulation.ndim > 1:
         add_int("simulation/grid/nbr_cells/y", simulation.cells[1])
         add_double("simulation/grid/meshsize/y", simulation.dl[1])
         add_double("simulation/grid/origin/y", simulation.origin[1])
+        add_string("simulation/grid/boundary_type/y", simulation.boundary_types[1])
 
         if simulation.ndim > 2:
             add_int("simulation/grid/nbr_cells/z", simulation.cells[2])
             add_double("simulation/grid/meshsize/z", simulation.dl[2])
             add_double("simulation/grid/origin/z", simulation.origin[2])
+            add_string("simulation/grid/boundary_type/z", simulation.boundary_types[2])
 
     add_int("simulation/interp_order", simulation.interp_order)
     add_int("simulation/refined_particle_nbr", simulation.refined_particle_nbr)

--- a/src/amr/wrappers/hierarchy.hpp
+++ b/src/amr/wrappers/hierarchy.hpp
@@ -90,6 +90,8 @@ class Hierarchy : public HierarchyRestarter, public SAMRAI::hier::PatchHierarchy
 {
 public:
     NO_DISCARD static auto make();
+
+    NO_DISCARD auto const& boundaryConditions() const { return boundaryConditions_; }
     NO_DISCARD auto const& cellWidth() const { return cellWidth_; }
     NO_DISCARD auto const& domainBox() const { return domainBox_; }
     NO_DISCARD auto const& origin() const { return origin_; }
@@ -112,12 +114,14 @@ protected:
               std::shared_ptr<SAMRAI::tbox::MemoryDatabase>&& db,
               std::array<int, dimension> const domainBox,
               std::array<double, dimension> const origin,
-              std::array<double, dimension> const cellWidth);
+              std::array<double, dimension> const cellWidth,
+              std::array<std::string, dimension> const boundaryConditions);
 
 private:
     std::vector<double> const cellWidth_;
     std::vector<int> const domainBox_;
     std::vector<double> const origin_;
+    std::vector<std::string> boundaryConditions_;
 };
 
 
@@ -201,13 +205,15 @@ Hierarchy::Hierarchy(initializer::PHAREDict const& dict,
                      std::shared_ptr<SAMRAI::tbox::MemoryDatabase>&& db,
                      std::array<int, dimension> const domainBox,
                      std::array<double, dimension> const origin,
-                     std::array<double, dimension> const cellWidth)
+                     std::array<double, dimension> const cellWidth,
+                     std::array<std::string, dimension> const boundaryConditions)
     // needs to open restart database before SAMRAI::PatchHierarcy constructor
     : HierarchyRestarter{dict}
     , SAMRAI::hier::PatchHierarchy{"PHARE_hierarchy", geo, db}
     , cellWidth_(cellWidth.data(), cellWidth.data() + dimension)
     , domainBox_(domainBox.data(), domainBox.data() + dimension)
     , origin_(origin.data(), origin.data() + dimension)
+    , boundaryConditions_(boundaryConditions.data(), boundaryConditions.data() + dimension)
 {
 }
 
@@ -385,7 +391,6 @@ auto patchHierarchyDatabase(PHARE::initializer::PHAREDict const& amr)
 }
 
 
-
 template<std::size_t _dimension>
 DimHierarchy<_dimension>::DimHierarchy(PHARE::initializer::PHAREDict const& dict)
     : Hierarchy{
@@ -396,7 +401,8 @@ DimHierarchy<_dimension>::DimHierarchy(PHARE::initializer::PHAREDict const& dict
         patchHierarchyDatabase<dimension>(dict["simulation"]["AMR"]),
         shapeToBox(parseDimXYZType<int, dimension>(dict["simulation"]["grid"], "nbr_cells")),
         parseDimXYZType<double, dimension>(dict["simulation"]["grid"], "origin"),
-        parseDimXYZType<double, dimension>(dict["simulation"]["grid"], "meshsize")}
+        parseDimXYZType<double, dimension>(dict["simulation"]["grid"], "meshsize"),
+        parseDimXYZType<std::string, dimension>(dict["simulation"]["grid"], "boundary_type")}
 {
 }
 

--- a/src/core/data/grid/gridlayout.hpp
+++ b/src/core/data/grid/gridlayout.hpp
@@ -279,7 +279,7 @@ namespace core
 
             auto xyz = tuple_fixed_type<std::vector<double>, dimension>{};
 
-            for (const auto& indiceTuple : indices)
+            for (auto const& indiceTuple : indices)
                 std::apply(
                     [&](auto const&... args) {
                         emplace_back(

--- a/src/core/utilities/mpi_utils.hpp
+++ b/src/core/utilities/mpi_utils.hpp
@@ -52,6 +52,8 @@ NO_DISCARD auto mpi_type_for()
         return MPI_UINT64_T;
     else if constexpr (std::is_same_v<char, Data>)
         return MPI_CHAR;
+    else if constexpr (std::is_same_v<std::string, Data>)
+        return MPI_CHAR;
 
     // don't return anything = compile failure if tried to use this function
 }

--- a/src/diagnostic/detail/h5typewriter.hpp
+++ b/src/diagnostic/detail/h5typewriter.hpp
@@ -108,8 +108,8 @@ protected:
         }
 
         if (diagnostic.nAttributes > 0)
-            h5Writer_.writeAttributeDict(file, diagnostic.fileAttributes, "/py_attrs");
-        h5Writer_.writeAttributeDict(file, fileAttributes, "/");
+            h5Writer_.writeGlobalAttributeDict(file, diagnostic.fileAttributes, "/py_attrs");
+        h5Writer_.writeGlobalAttributeDict(file, fileAttributes, "/");
     }
 
     template<typename ParticlePopulation>
@@ -119,14 +119,14 @@ protected:
 
         Attributes popAttributes;
         popAttributes["pop_mass"] = pop.mass();
-        h5Writer.writeAttributeDict(file, popAttributes, "/");
+        h5Writer.writeGlobalAttributeDict(file, popAttributes, "/");
     }
 
     void writeGhostsAttr_(HighFiveFile& file, std::string path, std::size_t ghosts, bool null)
     {
         Attributes dsAttr;
         dsAttr["ghosts"] = ghosts;
-        h5Writer_.writeAttributeDict(file, dsAttr, null ? "" : path);
+        h5Writer_.writeGlobalAttributeDict(file, dsAttr, null ? "" : path);
     }
 
     template<typename FileMap, typename... Quantities>

--- a/src/diagnostic/diagnostic_model_view.hpp
+++ b/src/diagnostic/diagnostic_model_view.hpp
@@ -37,7 +37,8 @@ public:
     using GridLayout = typename Model::gridlayout_type;
     using PatchProperties
         = cppdict::Dict<float, double, std::size_t, std::vector<int>, std::vector<std::uint32_t>,
-                        std::vector<double>, std::vector<std::size_t>, std::string>;
+                        std::vector<double>, std::vector<std::size_t>, std::string,
+                        std::vector<std::string>>;
 
     ModelView(Hierarchy& hierarchy, Model& model)
         : model_{model}
@@ -60,6 +61,7 @@ public:
                                                std::forward<Action>(action), minLevel, maxLevel,
                                                model_);
     }
+    NO_DISCARD auto boundaryConditions() const { return hierarchy_.boundaryConditions(); }
 
     NO_DISCARD auto domainBox() const { return hierarchy_.domainBox(); }
 
@@ -71,6 +73,7 @@ public:
     {
         return std::string{GridLayout::implT::type};
     }
+
 
     NO_DISCARD auto getPatchProperties(std::string patchID, GridLayout const& grid) const
     {

--- a/tests/diagnostic/test_diagnostics.hpp
+++ b/tests/diagnostic/test_diagnostics.hpp
@@ -252,6 +252,7 @@ void validateAttributes(Simulator& sim, Hi5Diagnostic& hi5)
         EXPECT_EQ(expected, attr);
     };
 
+    std::vector<std::string> const boundaryTypes(dimension, "periodic");
     std::size_t popAttrChecks = 0;
     for (auto const& fileType : h5FileTypes)
     {
@@ -277,6 +278,7 @@ void validateAttributes(Simulator& sim, Hi5Diagnostic& hi5)
             double pop_mass = 0;
             rootGroup.getAttribute("pop_mass").read(pop_mass);
             EXPECT_DOUBLE_EQ(pop_mass, 1.0);
+            _check_equal(rootGroup, boundaryTypes, "boundary_conditions");
         }
     }
     EXPECT_EQ(popAttrChecks, expectedPopNbr * expectedPopAttrFiles);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced simulation configuration with the ability to specify boundary types for all dimensions (x, y, z).
  - Introduced new configuration options to add string, double, and integer values to the simulation settings.

- **Bug Fixes**
  - Adjusted the diagnostic data writing process to correctly handle global attributes.
  - Updated the HDF5 file handling to properly manage attribute creation and data type checks.

- **Documentation**
  - Updated function usage and signatures for new configuration options in the simulation setup.

- **Refactor**
  - Improved boundary condition handling in the simulation grid setup.
  - Enhanced MPI utilities to support string data types.
  - Refined attribute handling in diagnostic outputs for better clarity and consistency.

- **Tests**
  - Added new tests to verify the correct initialization of boundary types in diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->